### PR TITLE
Feedback from PM

### DIFF
--- a/bin/play
+++ b/bin/play
@@ -11,4 +11,3 @@ game = Game.new(board)
 game.welcome_instructions
 game.get_game_type
 game.play_game
-game.show_outcome

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -30,8 +30,7 @@ class Board
   end
 
   def get_opponent_mark(given_mark)
-    opponent = PLAYER_MARKS.reject{|player_mark| player_mark == given_mark}
-    opponent[0]
+    PLAYER_MARKS.find { |player_mark| player_mark != given_mark }
   end
 
   def available_moves

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,5 +1,5 @@
 class Board
-  attr_reader :current_board
+  attr_reader :board_grid
 
   WINNING_COMBINATIONS = [
     [0, 1, 2],
@@ -15,18 +15,18 @@ class Board
   PLAYER_MARKS = ["X", "O"]
 
   def initialize(board)
-    @current_board = board
+    @board_grid = board
   end
 
   def mark_board(move, mark)
     position = move.to_i - 1
-    @current_board[position] = mark.upcase
-    @current_board
+    @board_grid[position] = mark.upcase
+    @board_grid
   end
  
   def clear_mark(move)
     position = move.to_i - 1
-    @current_board[position] = move
+    @board_grid[position] = move
   end
 
   def get_opponent_mark(given_mark)
@@ -36,7 +36,7 @@ class Board
 
   def available_moves
     available_moves = []
-    @current_board.each do |spot|
+    @board_grid.each do |spot|
       if spot != "X" && spot != "O"
         available_moves.push(spot)
       end
@@ -46,7 +46,7 @@ class Board
 
   def player_wins?(mark)
     WINNING_COMBINATIONS.any? do |combination|
-      combination.all? { |position| @current_board[position] == mark.upcase }
+      combination.all? { |position| @board_grid[position] == mark.upcase }
     end
   end
 

--- a/lib/computer.rb
+++ b/lib/computer.rb
@@ -7,13 +7,13 @@ class Computer
   end
 
   def get_move
-    return winning_move if winning_move != nil
-    return block_opponent if block_opponent != nil
+    return winning_move if winning_move 
+    return block_opponent if block_opponent 
     @board.available_moves.sample 
   end
  
   def winning_move
-    best_play = nil 
+    best_play = false
 
     @board.available_moves.each do |move|
       @board.mark_board(move, @mark)
@@ -27,7 +27,7 @@ class Computer
   end
 
   def block_opponent
-    best_play = nil 
+    best_play = false 
     opponent = @board.get_opponent_mark(@mark)
 
     @board.available_moves.each do |move|

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -48,6 +48,7 @@ class Game
         toggle_player
       end
     end
+    show_outcome
   end
 
   def check_move(move)

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -40,7 +40,7 @@ class Game
   def play_game
     until over?
      system('clear') 
-      @display.show_board(@board.current_board)
+      @display.show_board(@board.board_grid)
       @display.prompt_player(@current_player.mark)
       move = @current_player.get_move
       check_move(move)
@@ -94,7 +94,7 @@ class Game
 
   def show_outcome
     system('clear')
-    @display.show_board(@board.current_board)
+    @display.show_board(@board.board_grid)
     if is_a_tie?
       @display.announce_tie
     else

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -48,6 +48,7 @@ class Game
         toggle_player
       end
     end
+    system('clear')
     show_outcome
   end
 
@@ -94,7 +95,6 @@ class Game
   end
 
   def show_outcome
-    system('clear')
     @display.show_board(@board.board_grid)
     if is_a_tie?
       @display.announce_tie

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -27,4 +27,9 @@ RSpec.describe Board do
     board = Board.new(tied_game)
     expect(board.full?).to eq(true)
   end
+  
+  it "returns the opponent player's mark when given the current player's mark" do 
+    board = Board.new(empty_board)
+    expect(board.get_opponent_mark("X")).to eq("O")
+  end
 end

--- a/spec/computer_spec.rb
+++ b/spec/computer_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe Computer do
     expect(computer.get_move).to eq(7)
   end
  
-  it "randomly selects an available move from the board when both winning_move and block_opponent evaluate to nil" do
-    expect(computer.winning_move).to be_nil
-    expect(computer.block_opponent).to be_nil
+  it "randomly selects an available move from the board when both winning_move and block_opponent evaluate to false" do
+    expect(computer.winning_move).to eq(false)
+    expect(computer.block_opponent).to eq(false)
     expect(computer.get_move).not_to be_nil
   end
 end

--- a/spec/display_spec.rb
+++ b/spec/display_spec.rb
@@ -3,10 +3,10 @@ require "game"
 require "display"
 
 RSpec.describe Display do
+  let(:display) { Display.new }
+
   describe "#greet_players" do
     it "greets the players when the game starts" do
-      game = Game.new(Board.new(empty_board))
-      display = Display.new
 
       expect do
         display.greet_players
@@ -16,11 +16,9 @@ RSpec.describe Display do
 
   describe "#show_board" do
     it "shows a board" do
-      game = Game.new(Board.new(empty_board))
-      display = Display.new
 
       expect do
-        display.show_board(game.board.current_board)
+        display.show_board(empty_board)
       end.to output("" "
     1 | 2 | 3
     ---------
@@ -34,7 +32,6 @@ RSpec.describe Display do
     it "prompts the player to make a move" do
       game = Game.new(Board.new(empty_board))
       game.create_players("hh")
-      display = Display.new
 
       expect do
         display.prompt_player(game.current_player.mark)
@@ -45,7 +42,6 @@ RSpec.describe Display do
   describe "#notify_invalid" do
     it "tell the player they have attempted an invalid move" do
       game = Game.new(Board.new(empty_board))
-      display = Display.new
 
       expect do
         display.notify_invalid("move")
@@ -56,7 +52,6 @@ RSpec.describe Display do
   describe "#announce_tie" do
     it "returns 'it's a tie' when the game has ended and resulted in a tie" do
       game = Game.new(Board.new(tied_game))
-      display = Display.new
 
       expect do
         display.announce_tie
@@ -68,7 +63,6 @@ RSpec.describe Display do
     it "returns 'X wins!' when the game has ended because a player has won" do
       game = Game.new(Board.new(player_has_won))
       game.create_players("hh")
-      display = Display.new
 
       expect do
         display.announce_win(game.current_player.mark)


### PR DESCRIPTION
- renames the current_board to board_grid 
- uses the find enumerable method to get the opponent's mark when given the current player's mark
- removes double negatives in computer's get_move method
- moves responsibility for showing the outcome of the game away from the game launchers
- moves the system clear instruction to sit at a similar level of abstraction as the other system clear call
